### PR TITLE
Improve description of metadata and dimension field in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,18 +43,18 @@ This script can be run standalone or as a container.  In order to use the script
 
 All Global properties can be overridden per target.  Each Global property applies to each target, unless the target overrides it.
 
-| Key                      | Type   | Description                                                                                                       | Required                   | Default |
-| ---                      | -----  | -----------                                                                                                       | --------                   | ------- |
-| `sumo_http_url`          | URL    | The Sumo Logic HTTP source URL.  This can be configured globally, or per target.                                  | Yes (Unless set in Target) | None    | 
-| `run_interval_seconds`   | int    | The interval in seconds in which the target should be scraped.  This can be configured globally, or per target.   | No                         | 60      | 
-| `target_threads`         | int    | The number of threads to use when POST metrics to Sumo Logic.                                                     | No                         | 10      | 
-| `retries`                | int    | The number of times to retry sending data to Sumo Logic in the event of issue.                                    | No                         | 5       | 
-| `backoff_factor`         | float  | The back off factor to use when retrying.                                                                         | No                         | .2      | 
-| `source_category`        | String | The source category to assign to all data from every target, unless overridden in target.                         | No                         | None    | 
-| `source_host`            | String | The source host to assign to all data from every target, unless overridden in target.                             | No                         | None    | 
-| `source_name`            | String | The source name to assign to all data from every target, unless overridden in target.                             | No                         | None    | 
-| `dimensions`             | String | Additional dimensions to assign to all data from every target, unless overridden in target.                       | No                         | None    | 
-| `metadata`               | String | Additional metadata to assign to all data from every target, unless overridden in target.                         | No                         | None    | 
+| Key                      | Type   | Description                                                                                                                          | Required                   | Default |
+| ---                      | -----  | -----------                                                                                                                          | --------                   | ------- |
+| `sumo_http_url`          | URL    | The Sumo Logic HTTP source URL.  This can be configured globally, or per target.                                                     | Yes (Unless set in Target) | None    | 
+| `run_interval_seconds`   | int    | The interval in seconds in which the target should be scraped.  This can be configured globally, or per target.                      | No                         | 60      | 
+| `target_threads`         | int    | The number of threads to use when POST metrics to Sumo Logic.                                                                        | No                         | 10      | 
+| `retries`                | int    | The number of times to retry sending data to Sumo Logic in the event of issue.                                                       | No                         | 5       | 
+| `backoff_factor`         | float  | The back off factor to use when retrying.                                                                                            | No                         | .2      | 
+| `source_category`        | String | The source category to assign to all data from every target, unless overridden in target.                                            | No                         | None    | 
+| `source_host`            | String | The source host to assign to all data from every target, unless overridden in target.                                                | No                         | None    | 
+| `source_name`            | String | The source name to assign to all data from every target, unless overridden in target.                                                | No                         | None    | 
+| `dimensions`             | String | Comma-separated key=value list of additional dimensions to assign to all data from every target, unless overridden in target.        | No                         | None    | 
+| `metadata`               | String | Comma-separated key=value list of additional metadata to assign to all data from every target, unless overridden in target.          | No                         | None    | 
 
 ### Target Properties
 | Key                       | Type      | Description                                                                                                                                           | Required  | Default |


### PR DESCRIPTION
It is not clear from the README that the `metadata` and `dimension` field accept only key value pairs. One of our customers faced an issue, where they copy pasted the `config.json` but it did not work as expected as they did not replace the values in
"dimensions": "INSERT_DIMENSIONS_HERE" and  "metadata": "INSERT_METADATA_HERE".
We should think of a way to improve this example so that it is more evident what are the expected values. As a start, I propose adding the expected value that these keys take, which I think should be present. 
These are also described in our docs [here](https://help.sumologic.com/Send-Data/Sources/02Sources-for-Hosted-Collectors/HTTP-Source/Upload_Metrics_to_an_HTTP_Source#Supported_HTTP_Headers)
(Suggest to review by removing whitespace changes `&w=1`)